### PR TITLE
Update use of YDLOpts to new name in yt-dlp-types

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ yt_dlp
 
 ### Dev
 mypy
-yt-dlp-types
+yt-dlp-types>=0.0.17
 pyinstaller

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,9 @@
-from yt_dlp import YDLOpts, YoutubeDL
+from yt_dlp import YoutubeDL
+import yt_dlp
 
 
 def download_x_video(url: str, output_dir: str = "./downloads"):
-    ydl_opts: YDLOpts = {
+    ydl_opts: yt_dlp._Params = {
         "outtmpl": f"{output_dir}/%(title).50s.%(ext)s",
         "quiet": False,
         "no_warnings": True,


### PR DESCRIPTION
0.0.17 changes the name to a private one for the moment due to typeshed requirements. https://github.com/python/typeshed/pull/14216

Soon the stubs will hopefully be in typeshed and then you would switch the dependency to `types-yt-dlp`.